### PR TITLE
Support Ziponly downloads

### DIFF
--- a/src/main/java/io/openshift/booster/catalog/Booster.java
+++ b/src/main/java/io/openshift/booster/catalog/Booster.java
@@ -27,6 +27,7 @@ public class Booster
    private String buildProfile;
    private String description = "No description available";
    private String boosterDescriptorPath = ".openshiftio/booster.yaml";
+   private String supportedDeploymentTypes = "";
    private Mission mission;
    private Runtime runtime;
    private Version version;
@@ -141,6 +142,20 @@ public class Booster
    public void setDescription(String description)
    {
       this.description = description;
+   }
+   
+   public String getSupportedDeploymentTypes()
+   {
+      return supportedDeploymentTypes;
+   }
+    
+   /**
+    * @param supportedDeploymentTypes the deployment types that are supported by this booster.
+    * Leaving it unset or empty means any and all deployment types
+    */
+   public void setSupportedDeploymentTypes(String supportedDeploymentTypes)
+   {
+      this.supportedDeploymentTypes = supportedDeploymentTypes;
    }
 
    /**

--- a/src/main/java/io/openshift/booster/catalog/BoosterCatalog.java
+++ b/src/main/java/io/openshift/booster/catalog/BoosterCatalog.java
@@ -109,6 +109,13 @@ public interface BoosterCatalog
    public interface Selector
    {
       /**
+       * Apply a {@link DeploymentType} filter to all the boosters
+       * @param deploymentType The deployment type to filter on
+       * @return The selector itself for chaining calls
+       */
+      Selector deploymentType(DeploymentType deploymentType);
+      
+      /**
        * Apply a {@link Runtime} filter to all the boosters
        * @param runtime The runtime to filter on
        * @return The selector itself for chaining calls

--- a/src/main/java/io/openshift/booster/catalog/BoosterCatalog.java
+++ b/src/main/java/io/openshift/booster/catalog/BoosterCatalog.java
@@ -17,6 +17,7 @@ import java.util.Set;
  * General operations for a set of {@link Booster} objects
  * 
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ * @author <a href="mailto:tschotan@redhat.com">Tako Schotanus</a>
  */
 public interface BoosterCatalog
 {
@@ -94,4 +95,76 @@ public interface BoosterCatalog
     */
    Optional<Booster> getBooster(Mission mission, Runtime runtime, Version version, String... labels);
 
+   /**
+    * Creates a new <code>Selector</code>
+    * @return A selector
+    */
+   Selector selector();
+
+   /**
+    * Performs filtering on a set of {@link Booster} objects and returns
+    * the set of {@link Runtime}s, {@link Mission}s, {@link Version}s or
+    * {@link Booster}s that satisfy the filters
+    */
+   public interface Selector
+   {
+      /**
+       * Apply a {@link Runtime} filter to all the boosters
+       * @param runtime The runtime to filter on
+       * @return The selector itself for chaining calls
+       */
+      Selector runtime(Runtime runtime);
+      
+      /**
+       * Apply a <code>Misson</code> filter to all the boosters
+       * @param mission The mission to filter on
+       * @return The selector itself for chaining calls
+       */
+      Selector mission(Mission mission);
+      
+      /**
+       * Apply a {@link Version} filter to all the boosters
+       * @param version The version to filter on
+       * @return The selector itself for chaining calls
+       */
+      Selector version(Version version);
+      
+      /**
+       * Filter out any boosters that don't have all the given labels
+       * @param labels The labels to filter on
+       * @return The selector itself for chaining calls
+       */
+      Selector labels(String[] labels);
+      
+      /**
+       * Returns all the {@link Runtime}s that satisfy the applied filters
+       * @return A set of runtimes
+       */
+      Set<Runtime> getRuntimes();
+      
+      /**
+       * Returns all the {@link Mission}s that satisfy the applied filters
+       * @return A set of missions
+       */
+      Set<Mission> getMissions();
+      
+      /**
+       * Returns all the {@link Version}s that satisfy the applied filters
+       * @return A set of versions
+       */
+      Set<Version> getVersions();
+      
+      /**
+       * Returns all the {@link Booster}s that satisfy the applied filters
+       * @return A collection of boosters
+       */
+      Collection<Booster> getBoosters();
+      
+      /**
+       * Returns the {@link Booster} that satisfies the applied filters.
+       * (In the case that several boosters are found one will be selected)
+       * @return An optional booster value
+       */
+      Optional<Booster> getBooster();
+   }
 }

--- a/src/main/java/io/openshift/booster/catalog/BoosterCatalogService.java
+++ b/src/main/java/io/openshift/booster/catalog/BoosterCatalogService.java
@@ -236,7 +236,7 @@ public class BoosterCatalogService implements BoosterCatalog
          // Read YAML entry
          booster = yaml.loadAs(reader, Booster.class);
       }
-      catch (IOException e)
+      catch (Exception e)
       {
          logger.log(Level.SEVERE, "Error while reading " + file, e);
       }

--- a/src/main/java/io/openshift/booster/catalog/BoosterCatalogService.java
+++ b/src/main/java/io/openshift/booster/catalog/BoosterCatalogService.java
@@ -44,6 +44,7 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.representer.Representer;
 
 import io.openshift.booster.CopyFileVisitor;
 import io.openshift.booster.catalog.spi.BoosterCatalogListener;
@@ -229,7 +230,9 @@ public class BoosterCatalogService implements BoosterCatalog
             Map<String, Runtime> runtimes, Map<String, Version> versions)
    {
       logger.info(() -> "Indexing " + file + " ...");
-      Yaml yaml = new Yaml(new YamlConstructor());
+      Representer rep = new Representer();
+      rep.getPropertyUtils().setSkipMissingProperties(true);
+      Yaml yaml = new Yaml(new YamlConstructor(), rep);
       Booster booster = null;
       try (BufferedReader reader = Files.newBufferedReader(file))
       {

--- a/src/main/java/io/openshift/booster/catalog/DeploymentType.java
+++ b/src/main/java/io/openshift/booster/catalog/DeploymentType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.openshift.booster.catalog;
+
+/**
+*
+* @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+*/
+public enum DeploymentType
+{
+  /**
+   * Deploy in Openshift
+   */
+  CD("Continuous delivery"),
+  /**
+   * Deploy as a ZIP file
+   */
+  ZIP("ZIP File"),
+  /**
+   * Deploy on Openshift.io (not used in launch)
+   */
+  OSIO("Openshift.io");
+
+  private String description;
+
+  private DeploymentType(String description)
+  {
+     this.description = description;
+  }
+
+  public String getDescription()
+  {
+     return description;
+  }
+}

--- a/src/test/java/io/openshift/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/openshift/booster/catalog/BoosterCatalogServiceTest.java
@@ -119,6 +119,15 @@ public class BoosterCatalogServiceTest
    }
 
    @Test
+   public void testGetMissionByDeploymentType() throws Exception
+   {
+      BoosterCatalogService service = buildDefaultCatalogService();
+      service.index().get();
+      Set<Mission> missions = service.selector().deploymentType(DeploymentType.ZIP).getMissions();
+      assertThat(missions.size()).isGreaterThan(1);
+   }
+
+   @Test
    public void testGetRuntimes() throws Exception
    {
       BoosterCatalogService service = buildDefaultCatalogService();


### PR DESCRIPTION
Implementation for https://github.com/openshiftio/appdev-planning/issues/64

This PR consists of:

 - Adding a `supportedDeploymentTypes` option to the `Booster`
 - More flexible filtering of boosters
 - Adding possibility to filter on DeploymentType (this class was moved to this project for that purpose)

Btw, I'd suggest deprecating/removing all the `getMissions()`, `getRuntimes()` methods in the `BoosterCatalog` in favor of using the new `BoosterCatalog.Selector` everywhere.